### PR TITLE
add taboola to block huge 'articles you might like' ads

### DIFF
--- a/fritzbox-blacklist.txt
+++ b/fritzbox-blacklist.txt
@@ -10,6 +10,7 @@ adspirit.de
 adtech.de
 adzmob.com
 buysellads.com
+cdn.taboola.com
 conduit.com
 doubleclick.com
 doubleclick.net


### PR DESCRIPTION
These ones are quite annoying, I think, they come up on blog/news sites with very large links to spam articles you "might" be interested in.