### PR TITLE
Block .zip and .mov tld

### DIFF
--- a/fritzbox-blacklist.txt
+++ b/fritzbox-blacklist.txt
@@ -28,6 +28,7 @@ intellitxt.com
 ivwbox.de
 lgad.cjpowercast.com
 lgsmartad.com
+mov
 ngfts.lge.com
 nuggad.net
 outbrain.com
@@ -44,3 +45,4 @@ statcounter.com
 tradedoubler.com
 trafficholder.com
 teads.tv
+zip


### PR DESCRIPTION
Closses issue #19

These top-level domains are proven to be a security risk and should be blocked.